### PR TITLE
Add missing <cstdint> header to action.h to fix compile error on GCC 13

### DIFF
--- a/utils/action.h
+++ b/utils/action.h
@@ -3,6 +3,8 @@
 
 #include "player.h"
 
+#include <cstdint>
+
 struct Action
 {
     time_t timestamp = 0;


### PR DESCRIPTION
GCC 13 is stricter about required headers compared to GCC 11, which allowed <cstdint> to be omitted without errors.